### PR TITLE
Fix deploy: remove /etc/timezone mounts for Ubuntu 25.10

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -23,7 +23,6 @@ services:
     env_file:
       - .env
     volumes:
-      - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     restart: always
     depends_on:
@@ -41,7 +40,6 @@ services:
       POSTGRES_DB: vas3k_blog
     volumes:
       - /home/ubuntu/pgdata_heynik_blog:/var/lib/postgresql/data:rw
-      - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
       - "127.0.0.1:54324:5432"


### PR DESCRIPTION
## Summary
- Ubuntu 25.10 no longer has `/etc/timezone` as a regular file, causing Docker container startup to fail with: `error mounting "/etc/timezone": not a directory`
- Removed `/etc/timezone` mounts from both `blog_app` and `postgres` services
- `/etc/localtime` mount is sufficient for timezone configuration

## Test plan
- [ ] CI deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)