### PR TITLE
Fix crash: upgrade packaging from 24.0 to >=24.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -814,14 +814,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "24.0"
+version = "26.0"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
-    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+    {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
+    {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
 ]
 
 [[package]]
@@ -1770,4 +1770,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "56b05dbe7685782f33cc842e0e2bb0d1ac6f39ee95ae5a6fbd13f3fcfd3513ba"
+content-hash = "a039fce51060d69c4484f96025a1601a92fdc2f223bfcc98d02cbb8bf1283350"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Nik Ray <hi@nikilyushk.in>"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-packaging = "24.0"
+packaging = ">=24.1"
 Django = "^4.2.17"
 python-slugify = "^8.0.0"
 psycopg2-binary = "^2.9.5"


### PR DESCRIPTION
## Summary
- App container crash-loops with `No module named 'packaging.licenses'`
- `packaging.licenses` was added in 24.1, but pyproject.toml pinned to 24.0
- Updated to `>=24.1` (resolves to 26.0)

## Test plan
- [ ] Container starts without restart loop after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)