### PR TITLE
Optimize CI/CD: Docker layer caching, bump actions, remove sleep

### DIFF
--- a/.github/workflows/check_build_and_run.yml
+++ b/.github/workflows/check_build_and_run.yml
@@ -6,13 +6,19 @@ jobs:
   dockerize:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Build the docker-compose stack
-        run: docker-compose up -d
-      - name: Sleep
-        uses: jakejarvis/wait-action@master
-        with:
-          time: '20s'
+        run: docker compose up -d
+      - name: Wait for services to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if docker compose exec -T blog_app python3 -c "import django" 2>/dev/null; then
+              echo "App is ready"
+              break
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 2
+          done
       - name: Check db migrate on container
         run: |
-          docker-compose exec -T blog_app make migrate
+          docker compose exec -T blog_app make migrate

--- a/.github/workflows/check_build_and_run.yml
+++ b/.github/workflows/check_build_and_run.yml
@@ -8,7 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build the docker-compose stack
-        run: docker compose up -d
+        run: |
+          touch .env
+          docker compose up -d
       - name: Wait for services to be ready
         run: |
           for i in $(seq 1 30); do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,21 +13,26 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build & push ARM64 image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ghcr.io/${{ github.actor }}/blog:latest
             ghcr.io/${{ github.actor }}/blog:${{ github.sha }}
@@ -41,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Make envfile
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM ubuntu:24.04
 
-# ENV PIP_NO_CACHE_DIR=true
 ENV POETRY_VIRTUALENVS_CREATE=false
 ENV PIP_DISABLE_PIP_VERSION_CHECK=true
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
-
-RUN date
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -yq \
@@ -18,12 +15,13 @@ RUN apt-get update \
       make \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
-COPY . /app
+RUN pip3 install tzdata pytz poetry --break-system-packages
 
-RUN pip3 install tzdata
-RUN pip3 install pytz
-RUN pip3 install poetry --break-system-packages
-RUN poetry install --no-interaction --no-ansi
+WORKDIR /app
+
+COPY pyproject.toml poetry.lock /app/
+RUN poetry install --no-interaction --no-ansi --no-root
+
+COPY . /app
 
 CMD ["make", "docker-run-production"]


### PR DESCRIPTION
## Summary
- **Dockerfile**: Copy `pyproject.toml`/`poetry.lock` before app code so dependency install is cached across builds (biggest speedup)
- **Dockerfile**: Merge 3 `pip install` commands into 1 layer
- **deploy.yml**: Enable GitHub Actions BuildKit cache (`cache-from`/`cache-to`)
- **deploy.yml**: Bump `actions/checkout` v3→v4, `docker/login-action` v2→v3, `docker/build-push-action` v4→v6 (fixes Node.js 20 deprecation)
- **check_build_and_run.yml**: Replace hardcoded 20s sleep with a retry loop, bump checkout to v4, use `docker compose` v2

## Expected impact
- Code-only changes (no dependency updates) should build significantly faster due to cached dependency layer
- Subsequent builds reuse GHA cache for all Docker layers
- No more Node.js 20 deprecation warnings

## Test plan
- [ ] CI build passes on this PR
- [ ] Deploy workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)