### PR TITLE
Security: bump urllib3 to ^2.6.3 and sqlparse to ^0.5.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1416,18 +1416,18 @@ files = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.1"
+version = "0.5.5"
 description = "A non-validating SQL parser."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "sqlparse-0.5.1-py3-none-any.whl", hash = "sha256:773dcbf9a5ab44a090f3441e2180efe2560220203dc2f8c0b0fa141e18b505e4"},
-    {file = "sqlparse-0.5.1.tar.gz", hash = "sha256:bb6b4df465655ef332548e24f08e205afc81b9ab86cb1c45657a7ff173a3a00e"},
+    {file = "sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba"},
+    {file = "sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e"},
 ]
 
 [package.extras]
-dev = ["build", "hatch"]
+dev = ["build"]
 doc = ["sphinx"]
 
 [[package]]
@@ -1551,20 +1551,21 @@ devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)
 
 [[package]]
 name = "urllib3"
-version = "1.26.20"
+version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
-    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
+    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
+    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
 
 [package.extras]
-brotli = ["brotli (==1.0.9) ; os_name != \"nt\" and python_version < \"3\" and platform_python_implementation == \"CPython\"", "brotli (>=1.0.9) ; python_version >= \"3\" and platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; (os_name != \"nt\" or python_version >= \"3\") and platform_python_implementation != \"CPython\"", "brotlipy (>=0.6.0) ; os_name == \"nt\" and python_version < \"3\""]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress ; python_version == \"2.7\"", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
+h2 = ["h2 (>=4,<5)"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "uvicorn"
@@ -1833,4 +1834,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "b956375162e049575c5845f39716b6c814953bec76c21407e8d5ba9dbdef62b0"
+content-hash = "8c55f459c3333ba36cd37b53d111b638be414383159f049d7ce8de4b51f4ba9c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ gunicorn = "^22.0.0"
 uvicorn = {extras = ["standard"], version = "^0.20.0"}
 sentry-sdk = "^2.8.0"
 Authlib = "^1.6.9"
-#urllib3 = "^2.2.2"
-urllib3 = "<2.0.0"
+urllib3 = "^2.6.3"
 tzdata = "^2024.1"
+sqlparse = "^0.5.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2"


### PR DESCRIPTION
## Summary
- **urllib3** `<2.0.0` → `^2.6.3` — fixes 3 high severity decompression-bomb vulnerabilities (CVE-2026-21441, CVE-2025-66471, CVE-2025-66418)
- **sqlparse** (new explicit dep) `^0.5.4` — fixes DoS vulnerability in formatting

### Not fixable yet
- **tornado** stuck at 6.1 — hard-pinned by `python-telegram-bot ^13.15`. Would require upgrading to python-telegram-bot v20+ (major async rewrite)

## Test plan
- [ ] CI build passes
- [ ] App starts and blog loads correctly (urllib3 2.x is a major version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)