### PR TITLE
Fix code scanning: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/check_build_and_run.yml
+++ b/.github/workflows/check_build_and_run.yml
@@ -5,6 +5,8 @@ on: [pull_request]
 jobs:
   dockerize:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Build the docker-compose stack

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Build & Push ARM64 Image
     runs-on: ubuntu-22.04-arm
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code
@@ -41,6 +44,8 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
     env:
       SSH_KEY_PATH: /tmp/ssh_key
 


### PR DESCRIPTION
## Summary
- Added explicit `permissions` to all 3 workflow jobs to follow least-privilege principle
- `build` job: `contents: read` + `packages: write` (needs to push Docker images to GHCR)
- `deploy` job: `contents: read`
- `dockerize` (PR check) job: `contents: read`

Fixes all 3 CodeQL code-scanning alerts.

## Test plan
- [ ] CI build passes
- [ ] Deploy still works (GHCR push + SSH deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)