### PR TITLE
Cherry-pick upstream: mobile CSS, Docker log limits, dark mode fix

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -29,6 +29,11 @@ services:
       - postgres
     ports:
       - "127.0.0.1:8022:8022"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100M"
+        max-file: "3"
 
   postgres:
     image: postgres:15
@@ -43,3 +48,8 @@ services:
       - /etc/localtime:/etc/localtime:ro
     ports:
       - "127.0.0.1:54324:5432"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100M"
+        max-file: "3"

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -261,8 +261,16 @@
         }
 
         @media only screen and (max-width : 570px) {
+            .headline {
+                min-height: auto;
+            }
+
+            .headline-image {
+                min-height: 370px;
+            }
+
             .headline-info {
-                font-size: 160%;
+                font-size: 180%;
             }
         }
 

--- a/frontend/static/css/posts.css
+++ b/frontend/static/css/posts.css
@@ -178,10 +178,6 @@
         max-width: 100%;
     }
 
-    html[theme="dark"] .post img[src$=".png"] {
-        filter: invert(85%) hue-rotate(180deg);
-    }
-
     .post big {
         font-size: 120%;
     }


### PR DESCRIPTION
## Summary
Cherry-picked useful changes from upstream (vas3k/vas3k.blog):

- **Mobile CSS fixes** (bcb4436) — better headline sizing on small screens
- **Docker log size limits** (d74d511) — caps logs at 100MB x 3 files on both containers, prevents disk fill
- **Remove PNG invert filter in dark mode** (162739d) — the existing dark mode had an aggressive CSS rule that inverted all PNG images, distorting photos and screenshots

Note: Dark mode itself was already in the fork — only the PNG invert fix was needed.

## Test plan
- [ ] CI build passes
- [ ] Dark mode PNGs render correctly
- [ ] Mobile layout looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)